### PR TITLE
Add types folder and first type file

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,7 @@
     "**/*.tsx",
     "**/*.cjs",
     "**/*.js",
+    "./types/*.ts",
     ".next/types/**/*.ts"
   ],
   "exclude": ["node_modules"]

--- a/types/declare_modules.d.ts
+++ b/types/declare_modules.d.ts
@@ -1,0 +1,5 @@
+declare module "*.svg" {
+  import React = require("react");
+  const ReactComponent: React.FC<React.SVGProps<SVGSVGElement>>;
+  export default ReactComponent;
+}


### PR DESCRIPTION
Add a folder to store all type files

Once this is merged into DEV we should do a PR into main and add back the removed 'npm run type-check' command to the GitHub actions/

The type-check failed as the 'next-env.d.ts' file  is git ignored so is not available in the GitHub environment. 