### PR TITLE
refactor: move location call for convertURLtoTitle helper function

### DIFF
--- a/src/app/(household)/chores/[slug]/page.tsx
+++ b/src/app/(household)/chores/[slug]/page.tsx
@@ -5,12 +5,12 @@ import ItemsList from "./ItemsList";
 import Link from "next/link";
 import { navbarLinks } from "@/app/utils/navbarLinks";
 import { ArrowUturnLeftIcon } from "@heroicons/react/24/solid";
-import { convertURLtoTitle } from "@/app/utils/helperFunctions";
+import { convertURLtoString } from "@/app/utils/helperFunctions";
 
 
 export default async function Page({ params }: { params: { slug: string } }) {
   // lets try fetching chores by their name as we expect uniqueness between households
-  const choresName = convertURLtoTitle(params.slug);
+  const choresName = convertURLtoString(params.slug);
   const choresList = await api.choresItem.list.query({ title: choresName });
 
   return (

--- a/src/app/(household)/chores/[slug]/page.tsx
+++ b/src/app/(household)/chores/[slug]/page.tsx
@@ -10,7 +10,7 @@ import { convertURLtoTitle } from "@/app/utils/helperFunctions";
 
 export default async function Page({ params }: { params: { slug: string } }) {
   // lets try fetching chores by their name as we expect uniqueness between households
-  const choresName = params.slug;
+  const choresName = convertURLtoTitle(params.slug);
   const choresList = await api.choresItem.list.query({ title: choresName });
 
   return (
@@ -21,7 +21,7 @@ export default async function Page({ params }: { params: { slug: string } }) {
             <ArrowUturnLeftIcon className="text-[#b372f0]" />
           </Link>
           <h1 className="text-center text-3xl font-extrabold tracking-tight md:text-[2rem] lg:text-[3rem] xl:text-[4rem]">
-            {convertURLtoTitle(choresName)}
+            {choresName}
           </h1>
         </header>
         <div className="mt-5 flex justify-center">

--- a/src/app/(household)/shoppingLists/[slug]/page.tsx
+++ b/src/app/(household)/shoppingLists/[slug]/page.tsx
@@ -5,12 +5,12 @@ import ItemsList from "./ItemsList";
 import Link from "next/link";
 import {navbarLinks} from "@/app/utils/navbarLinks";
 import { ArrowUturnLeftIcon } from "@heroicons/react/24/solid";
-import { convertURLtoTitle } from "@/app/utils/helperFunctions";
+import { convertURLtoString } from "@/app/utils/helperFunctions";
 
 
 export default async function Page({ params }: { params: { slug: string } }) {
   // lets try fetching shopping list by its name as we expect uniqueness between households
-  const shoppingListName = convertURLtoTitle(params.slug);
+  const shoppingListName = convertURLtoString(params.slug);
   const shoppingList = await api.shoppingListItem.list.query({ title: shoppingListName });
   
   return (

--- a/src/app/(household)/shoppingLists/[slug]/page.tsx
+++ b/src/app/(household)/shoppingLists/[slug]/page.tsx
@@ -10,7 +10,7 @@ import { convertURLtoTitle } from "@/app/utils/helperFunctions";
 
 export default async function Page({ params }: { params: { slug: string } }) {
   // lets try fetching shopping list by its name as we expect uniqueness between households
-  const shoppingListName = params.slug;
+  const shoppingListName = convertURLtoTitle(params.slug);
   const shoppingList = await api.shoppingListItem.list.query({ title: shoppingListName });
   
   return (
@@ -21,7 +21,7 @@ export default async function Page({ params }: { params: { slug: string } }) {
             <ArrowUturnLeftIcon className="text-[#b372f0]" />
           </Link>
           <h1 className="text-center text-3xl font-extrabold tracking-tight md:text-[2rem] lg:text-[3rem] xl:text-[4rem]">
-            {convertURLtoTitle(shoppingListName)}
+            {shoppingListName}
           </h1>
         </header>
         <div className="mt-5 flex justify-center">

--- a/src/app/utils/helperFunctions.ts
+++ b/src/app/utils/helperFunctions.ts
@@ -6,7 +6,7 @@ export const sanitiseTitleStringForURL = (title: string) => {
   return formattedTitle
 }
 
-export const convertURLtoTitle = (title: string) => {
+export const convertURLtoString = (title: string) => {
   /** Format string to replace any hythen with a whitespace */
   const formattedTitle = title.replace(/-/g, ' ')
   return formattedTitle


### PR DESCRIPTION
convertURLtoTitle helper function in chores and shopping list dynamic pages has been relocated to change the page slug passed in as a parameter before being store in a variable.

This changes the variable used by the api and UI in one location for easier management.